### PR TITLE
A few fix for that branches of the sim

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 fs = require('fs');
-
+const TIMEZONE_ORDER = true;
 // Rock Paper Scissors
 const RPS = [
   /*         S      C       A     Z     D */
@@ -16,6 +16,9 @@ const MAX_MATCH = 20;
 const ADD_MATCH = 10;
 const FROZEN  = false
 let players;
+
+//toto: add new table so that sort by trophy  do not impact match order in following seasons.
+let sortedPlayers;
 let season = 1; // first season
 
 /**
@@ -271,21 +274,22 @@ function printTime() {
   * @return {void}
   */
 function printCSV() {
+  sortPlayers();
   csv = 'player id,bp,inactive,zone,hero,power,trophies,skip,win,loss,d win,d loss\n';
   for (i = 0; i < PLAYER_COUNT; i++) {
     csv +=
-      players[i].id + ',' +
-      players[i].bp + ',' +
-      players[i].inactive + ',' +
-      players[i].zone + ',' +
-      players[i].hero + ',' +
-      players[i].pwr + ',' +
-      players[i].trophies + ',' +
-      players[i].S + ',' +
-      players[i].W + ',' +
-      players[i].L + ',' +
-      players[i].dW + ',' +
-      players[i].dL + '\n';
+    sortedPlayers[i].id + ',' +
+    sortedPlayers[i].bp + ',' +
+    sortedPlayers[i].inactive + ',' +
+    sortedPlayers[i].zone + ',' +
+    sortedPlayers[i].hero + ',' +
+    sortedPlayers[i].pwr + ',' +
+    sortedPlayers[i].trophies + ',' +
+    sortedPlayers[i].S + ',' +
+    sortedPlayers[i].W + ',' +
+    sortedPlayers[i].L + ',' +
+    sortedPlayers[i].dW + ',' +
+    sortedPlayers[i].dL + '\n';
   }
   return csv;
 }
@@ -295,7 +299,9 @@ function printCSV() {
   * @return {void}
   */
 function sortPlayers() {
-  players.sort( function(a, b) {
+
+  sortedPlayers = players;
+  sortedPlayers.sort( function(a, b) {
 
     //toto: optimise sort :
     return b.trophies-a.trophies;
@@ -320,6 +326,7 @@ function sortPlayers() {
     }
     return player;   
   });
+  
 }
 /**
   * Simulate season (new system by dev)
@@ -338,7 +345,12 @@ function simulate3() {
       }
     
   }
-  
+
+  //toto: sort player by time zone or below code for tz is irrelevant
+  if(TIMEZONE_ORDER){
+    players.sort((a,b) => a.zone> b.zone );
+  }
+
   console.log(`Season ${season}`);
   for (day = 0; day < seasonDays; day++) {
     
@@ -376,7 +388,7 @@ reset();
 cleanTrophies();
 simulate3();
 fs.writeFileSync('players-1.json', JSON.stringify(players));
-sortPlayers();
+
 fs.writeFileSync(`players-1.csv`, printCSV());
 
 seasonDays = 14;
@@ -384,6 +396,6 @@ for (season = 2; season < 6; season++) {
   reset();
   simulate3();
   fs.writeFileSync(`players-${season}.json`, JSON.stringify(players));
-  sortPlayers();
+  
   fs.writeFileSync(`players-${season}.csv`, printCSV());
 }

--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ function battle(myId, oppId, winProbability, trophyChanges) {
   */
 function findOpponents(myId) {
   const MATCH_SEARCH_LEN = 400;
-  const MATCH_LIST_LEN = 40;
+  const MATCH_LIST_LEN = 100;
 
   const myHero = players[myId].hero;
   const myPwr = players[myId].pwr;
@@ -235,7 +235,7 @@ function findOpponents(myId) {
   }else{
     listB.sort( function(a, b) {
       //toto: small opimisation for live trophies
-     return (b.score_sanitized - b.score_sanitized) ;
+     return (b.score_sanitized - a.score_sanitized) ;
     });
   }
   return listB;
@@ -363,9 +363,10 @@ function simulate3() {
       console.log('Time Zone ' + z);
       for (let i = 0; i < ZONE_BRACKET; i++) {
         id = ZONE_BRACKET * z + i;
-        if (players[id].inactive) {
+        //if (players[id].inactive) {
           // do nothing
-        } else {
+        //} else 
+        {
           matchCount = (players[id].bp)?(MAX_MATCH+ADD_MATCH):(MAX_MATCH);
           const opponents = findOpponents(id);
           for (let match = 0; match < matchCount; match++) {

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function getWinProbability(myPwr, oppPwr) {
   * Get trophy change from battle result
   * @param {number} myTrophies offense
   * @param {number} oppTrophies defens
-  * @return {[number]} [attacker win, attacker loss, defense Win, defenser Loss]
+  * @return {[number]} [attackerwin, attacker loss, defense Win, defenser Loss]
   */
 function getTrophyChanges(myTrophies, oppTrophies) {
   const MAX_CHANGE = 32;
@@ -151,7 +151,7 @@ function battle(myId, oppId, winProbability, trophyChanges) {
     players[myId].W += 1;
     players[oppId].dL += 1;
     /// toto: adapted as defensive wins and losses are not symetrical
-    return [trophyChanges[0], trophyChanges[4]];
+    return [trophyChanges[0], trophyChanges[3]];
   }
 
   players[myId].L += 1;

--- a/index.js
+++ b/index.js
@@ -277,7 +277,7 @@ function printCSV() {
       players[i].id + ',' +
       players[i].bp + ',' +
       players[i].inactive + ',' +
-      players[i].timeZone + ',' +
+      players[i].zone + ',' +
       players[i].hero + ',' +
       players[i].pwr + ',' +
       players[i].trophies + ',' +

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 fs = require('fs');
+const FROZEN  = false
 
 // Rock Paper Scissors
 const RPS = [
@@ -155,7 +156,8 @@ function findOpponents(myId) {
     oppId = myId + Math.floor(Math.random() * PLAYER_COUNT);
     if (oppId >= PLAYER_COUNT) oppId = oppId - PLAYER_COUNT;
     const oppPwr = players[oppId].pwr;
-    const oppTrophies = players[oppId].locked;
+    // toto: optional frozen rule
+    const oppTrophies = FROZEN?players[oppId].locked: players[oppId].trophies;
     const fitness1 = Math.pow(0.9, Math.abs(myTrophies - oppTrophies) / 400);
     const fitness2 = Math.pow(0.9, Math.abs(myPwr - oppPwr) / 100000);
     const fitness = Math.round(Math.max(fitness1, fitness2) * 100);
@@ -174,7 +176,7 @@ function findOpponents(myId) {
   for (let j = 0; j < MATCH_LIST_LEN; j++) {
     const oppId = listB[j].id;
     const oppPwr = players[oppId].pwr;
-    const oppTrophies = players[oppId].locked;
+    const oppTrophies = FROZEN?players[oppId].locked: players[oppId].trophies;
     const oppHero = players[oppId].hero;
     const potential =
       getPotential(myHero, myPwr, myTrophies, oppHero, oppPwr, oppTrophies);
@@ -183,17 +185,24 @@ function findOpponents(myId) {
     listB[j].winProbability = potential.winProbability;
     listB[j].trophyChanges = potential.trophyChanges;
   }
-  listB.sort( function(a, b) {
-    if (a.score_sanitized > b.score_sanitized) {
-      return -1;
-    } else if (a.score_sanitized < b.score_sanitized) {
-      return 1;
-    } else if (players[a.id].locked > players[b.id].locked) {
-      return -1;
-    } else {
-      return 0;
-    }
-  });
+  if(FROZEN){
+    listB.sort( function(a, b) {
+      if (a.score_sanitized > b.score_sanitized) {
+        return -1;
+      } else if (a.score_sanitized < b.score_sanitized) {
+        return 1;
+      } else if (players[a.id].locked > players[b.id].locked) {
+        return -1;
+      } else {
+        return 0;
+      }
+    }); 
+  } else {
+    listB.sort( function(a, b) {
+      //toto: small opimisation for live trophies
+    return (b.score_sanitized - b.score_sanitized) ;
+    });
+  }
   return listB;
   //
   // let selected = 0;
@@ -281,7 +290,8 @@ function simulate3() {
 
   console.log(`Season ${season}`);
   for (day = 0; day < seasonDays; day++) {
-    lockTrophies();
+
+    if (FROZEN){lockTrophies();}
 
     console.log('Day ' + day + ' :' + printTime());
     const ZONE_BRACKET = PLAYER_COUNT/8;


### PR DESCRIPTION
Hi, Kit

I kept player distribution on 5 heros with rps and 1.4 m max power, 
but there were a few things that did not work as I would expect in  your current main branches of the simulation, probably because arena changed a lot since you did them.

-> calcs symetrical win and losses.
fixed, now an opponent that  in case of win  gives +32 and gets -16, in case of loss correctly gives -2 and gets +1

-> no win cap for konquerors
fixed, -3 in def in case of win above 4500

-> all calculations of win/loss where done on attacker's initial trophies for the day 
fixed, but it requires to remake the match list after each battle and slow down the simulation. 

Kind regards
Toto
NB: please run it overnight, with the 3 above issues fixed , there is a huge timezone advantage ;)